### PR TITLE
Add logging and error interceptors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,22 +9,27 @@
 
 [[projects]]
   name = "github.com/golang/protobuf"
-  packages = [
-    "proto",
-    "protoc-gen-go/descriptor",
-    "ptypes",
-    "ptypes/any",
-    "ptypes/duration",
-    "ptypes/timestamp"
-  ]
+  packages = ["jsonpb","proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/struct","ptypes/timestamp"]
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/grpc-ecosystem/go-grpc-middleware"
+  packages = ["."]
+  revision = "b9ed6aed6cf9de7330c7c8e81d3d8e49086539e8"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
 
 [[projects]]
   name = "github.com/stretchr/objx"
@@ -34,92 +39,49 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = [
-    ".",
-    "assert",
-    "http",
-    "mock"
-  ]
+  packages = ["assert","mock","require","suite"]
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "f70185d77e8278766928032ee1355e3da47e7181"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "http2",
-    "http2/hpack",
-    "idna",
-    "internal/timeseries",
-    "lex/httplex",
-    "trace"
-  ]
+  packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
   revision = "61147c48b25b599e5b561d2e9c4f3e1ef489ca41"
 
 [[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix","windows"]
+  revision = "3b87a42e500a6dc65dae1a55d0b641295971163e"
+
+[[projects]]
   name = "golang.org/x/text"
-  packages = [
-    "collate",
-    "collate/build",
-    "internal/colltab",
-    "internal/gen",
-    "internal/tag",
-    "internal/triegen",
-    "internal/ucd",
-    "language",
-    "secure/bidirule",
-    "transform",
-    "unicode/bidi",
-    "unicode/cldr",
-    "unicode/norm",
-    "unicode/rangetable"
-  ]
+  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
-  packages = [
-    "googleapis/api/annotations",
-    "googleapis/rpc/status"
-  ]
+  packages = ["googleapis/api/annotations","googleapis/rpc/status"]
   revision = "ce84044298496ef4b54b4a0a0909ba593cc60e30"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [
-    ".",
-    "balancer",
-    "balancer/base",
-    "balancer/roundrobin",
-    "codes",
-    "connectivity",
-    "credentials",
-    "encoding",
-    "encoding/proto",
-    "grpclb/grpc_lb_v1/messages",
-    "grpclog",
-    "internal",
-    "keepalive",
-    "metadata",
-    "naming",
-    "peer",
-    "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
-    "stats",
-    "status",
-    "tap",
-    "transport"
-  ]
+  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","encoding","encoding/proto","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
   revision = "d89cded64628466c4ab532d1f0ba5c220459ebe8"
   version = "v1.11.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bcdfd094e92845b5829a0dd508a6b5c39961b49f71273bcecb559a09326a32a7"
+  inputs-digest = "dfbf9b796cbc959d94b31d64f600cbdce131fdca75b90306f3bce498355bc2bf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,3 +40,6 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.1"
+
+[[constraint]]
+  name = "github.com/grpc-ecosystem/go-grpc-middleware"

--- a/server/api/errors.go
+++ b/server/api/errors.go
@@ -1,0 +1,20 @@
+package api
+
+import "fmt"
+
+// NotFoundErr is returned when a certain resource cannot be found
+type NotFoundErr struct {
+	// ResourceType should be assigned to the name of the resource type that was
+	// missing, for example: starship or vehicle
+	ResourceType string
+}
+
+// NotFound returns an initialized NotFoundErr type
+func NotFound(rt string) NotFoundErr {
+	return NotFoundErr{ResourceType: rt}
+}
+
+// Error implements error
+func (err NotFoundErr) Error() string {
+	return fmt.Sprintf("could not find %s", err.ResourceType)
+}

--- a/server/api/interceptor.go
+++ b/server/api/interceptor.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
+	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
+)
+
+// Interceptors implements the grpc.UnaryServerInteceptor function to add
+// interceptors around all gRPC calls
+func Interceptors() grpc.UnaryServerInterceptor {
+	return grpcmiddleware.ChainUnaryServer(
+		loggingInterceptor,
+		errorsInterceptor,
+	)
+}
+
+// errorsInterceptor adds error type checking to see if there are any known types
+// that we return different grpc error codes for, for example: NotFound resources.
+func errorsInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (out interface{}, err error) {
+	out, err = handler(ctx, req)
+
+	switch tErr := err.(type) {
+	case NotFoundErr:
+		return out, grpc.Errorf(codes.NotFound, tErr.Error())
+	}
+
+	return out, err
+}
+
+// loggingInterceptor adds logging around every gRPC call. It includes the method name and timing information.
+// if the given handler raises an error, it also appends that to a key.
+func loggingInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (out interface{}, err error) {
+	entry := logrus.WithField("method", info.FullMethod)
+	start := time.Now()
+	out, err = handler(ctx, req)
+	duration := time.Since(start)
+
+	if err != nil {
+		entry = entry.WithError(err)
+	}
+
+	entry.WithField("duration", duration.String()).Info("finished RPC")
+
+	return out, err
+}

--- a/server/api/interceptor.go
+++ b/server/api/interceptor.go
@@ -15,14 +15,14 @@ import (
 // interceptors around all gRPC calls
 func Interceptors() grpc.UnaryServerInterceptor {
 	return grpcmiddleware.ChainUnaryServer(
-		loggingInterceptor,
-		errorsInterceptor,
+		LoggingInterceptor,
+		ErrorsInterceptor,
 	)
 }
 
-// errorsInterceptor adds error type checking to see if there are any known types
-// that we return different grpc error codes for, for example: NotFound resources.
-func errorsInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (out interface{}, err error) {
+// ErrorsInterceptor adds error type checking to see if there are any known types
+// what we return different grpc error codes for, for example: NotFound resources.
+func ErrorsInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (out interface{}, err error) {
 	out, err = handler(ctx, req)
 
 	switch tErr := err.(type) {
@@ -33,9 +33,9 @@ func errorsInterceptor(ctx context.Context, req interface{}, info *grpc.UnarySer
 	return out, err
 }
 
-// loggingInterceptor adds logging around every gRPC call. It includes the method name and timing information.
+// LoggingInterceptor adds logging around every gRPC call. It includes the method name and timing information.
 // if the given handler raises an error, it also appends that to a key.
-func loggingInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (out interface{}, err error) {
+func LoggingInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (out interface{}, err error) {
 	entry := logrus.WithField("method", info.FullMethod)
 	start := time.Now()
 	out, err = handler(ctx, req)

--- a/server/api/interceptor_test.go
+++ b/server/api/interceptor_test.go
@@ -1,0 +1,36 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/backstopmedia/gRPC-book-example/server/api"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+func TestErrorsInterceptor(t *testing.T) {
+	t.Run("Errros interceptor returns a codes.NotFound when a DB not found is returned", func(t *testing.T) {
+		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			return nil, api.NotFoundErr{}
+		}
+
+		out, err := api.ErrorsInterceptor(nil, nil, nil, handler)
+		assert.Nil(t, out)
+		assert.Equal(t, codes.NotFound, grpc.Code(err))
+	})
+
+	t.Run("Errors interceptor returns the originl error if not applicable to intercept", func(t *testing.T) {
+		expErr := errors.New("Boom")
+
+		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			return nil, expErr
+		}
+
+		out, err := api.ErrorsInterceptor(nil, nil, nil, handler)
+		assert.Nil(t, out)
+		assert.Equal(t, expErr, err)
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -45,7 +45,8 @@ func main() {
 		log.Fatalf("unable to parse data file: %v", err)
 	}
 
-	s := grpc.NewServer()
+	interceptorOpt := grpc.UnaryInterceptor(api.Interceptors())
+	s := grpc.NewServer(interceptorOpt)
 	pb.RegisterStarwarsServer(s, api.New(db))
 
 	if err := s.Serve(list); err != nil {


### PR DESCRIPTION
This should play nicely with the other PRs that are open.

This adds 2 interceptors to the server unary calls:

* Simple tagged logging using logrus.
* Error checks and swaps if we get a hit. Used for NotFound right now.